### PR TITLE
ci(lint): increase Go linter timeout to 30min

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -24,6 +24,7 @@ jobs:
         working-directory: backend
       - uses: golangci/golangci-lint-action@v6
         with:
+          args: --timeout=30m
           version: latest
           working-directory: backend
 


### PR DESCRIPTION
The default is too low.