### PR TITLE
feat(codegen): apply Go formatting rules on generated code

### DIFF
--- a/backend/api/v1/groupversion_info.go
+++ b/backend/api/v1/groupversion_info.go
@@ -2,7 +2,7 @@
 // +kubebuilder:object:generate=true
 // +groupName=devbot.kfirs.com
 //
-//go:generate controller-gen object crd paths="." output:crd:artifacts:config=../../internal/devctl/resources/.devbot/crd
+//go:generate controller-gen object crd paths="." output:crd:artifacts:config=../../internal/devctl/bootstrap/resources/.devbot/crd
 //go:generate go run ../../scripts/generators/conditions .
 package v1
 


### PR DESCRIPTION
This change ensures that generated code is formatted according to idiomatic Go rules, via the Go format package. This helps prevent IDEs from changing these files or formatting them themselves, causing redundant commits.