### PR TITLE
ci(codegen): fail build if go generate has not been run

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -22,11 +22,7 @@ jobs:
           go-version-file: backend/go.mod
       - run: go mod download -x
         working-directory: backend
-      - uses: golangci/golangci-lint-action@v6
-        with:
-          args: --timeout=30m
-          version: latest
-          working-directory: backend
+      - run: go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.11.3
       - run: |
           rm -vrf backend/api/v1/zz_* deploy/app/crd/*.yaml
           cd backend && go generate ./...
@@ -34,3 +30,8 @@ jobs:
             echo "Go code generation created modifications - run 'go generate ./...' locally again."
             exit 1
           fi
+      - uses: golangci/golangci-lint-action@v6
+        with:
+          args: --timeout=30m
+          version: latest
+          working-directory: backend

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -23,13 +23,15 @@ jobs:
       - run: go mod download -x
         working-directory: backend
       - run: go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.13.0
+        working-directory: backend
       - run: |
-          rm -vrf backend/api/v1/zz_* deploy/app/crd/*.yaml
-          cd backend && go generate ./...
+          rm -vrf api/v1/zz_*
+          go generate ./...
           if [[ -n $(git status --porcelain) ]]; then
             echo "Go code generation created modifications - run 'go generate ./...' locally again."
             exit 1
           fi
+        working-directory: backend
       - uses: golangci/golangci-lint-action@v6
         with:
           args: --timeout=30m

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -22,7 +22,7 @@ jobs:
           go-version-file: backend/go.mod
       - run: go mod download -x
         working-directory: backend
-      - run: go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.11.3
+      - run: go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.13.0
       - run: |
           rm -vrf backend/api/v1/zz_* deploy/app/crd/*.yaml
           cd backend && go generate ./...

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -27,3 +27,10 @@ jobs:
           args: --timeout=30m
           version: latest
           working-directory: backend
+      - run: |
+          rm -vrf backend/api/v1/zz_* deploy/app/crd/*.yaml
+          cd backend && go generate ./...
+          if [[ -n $(git status --porcelain) ]]; then
+            echo "Go code generation created modifications - run 'go generate ./...' locally again."
+            exit 1
+          fi


### PR DESCRIPTION
This change ensures that developers run `go generate` before they push their changes. This helps ensure consistency of dynamic source code with generated source code.