### PR TITLE
feat: reap abandoned e2e GitHub repositories

### DIFF
--- a/.github/workflows/e2e-cleanup.yaml
+++ b/.github/workflows/e2e-cleanup.yaml
@@ -1,0 +1,21 @@
+name: Build
+
+on:
+  schedule:
+    - cron: '0 02 * * *'
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash --noprofile --norc -e -u -x -o pipefail {0}
+
+jobs:
+
+  reap-e2e-github-repositories:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          gh repo list devbot-testing --json=nameWithOwner \
+            | jq '.[]|.nameWithOwner' -r \
+            | sort \
+            | xargs -I@ gh repo delete --yes @

--- a/Makefile
+++ b/Makefile
@@ -59,10 +59,6 @@ undeploy:
 	kubectl get namespaces -oname | grep -v -E 'default|devbot|kube|local' | sort | xargs -I@ kubectl delete @  || true
 	kubectl delete namespace devbot || true
 	kubectl delete crd repositories.devbot.kfirs.com applications.devbot.kfirs.com deployments.devbot.kfirs.com environments.devbot.kfirs.com || true
-	gh repo list devbot-testing --json=nameWithOwner \
-      | jq '.[]|.nameWithOwner' -r \
-      | sort \
-      | xargs -I@ gh repo delete --yes @
 
 .PHONY: dev
 dev:


### PR DESCRIPTION
This change adds a daily workflow that deletes e2e-created GitHub repositories that for some reason have not been deleted by its post-run cleanup.