### PR TITLE
chore(make): remove GCP integration leftover from the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,6 @@ else
 endif
 #-----------------------------------------------------------------------------------------------------------------------
 
-deploy/otel-collector-gcp/service-account-key.json:
-	gcloud iam service-accounts keys create ./deploy/otel-collector-gcp/service-account-key.json --iam-account=otel-collector@arikkfir.iam.gserviceaccount.com
-
 .PHONY: setup
 setup:
 	npm install -g smee-client


### PR DESCRIPTION
This change removes a leftover from an experimental feature integrating an OTEL exporter to send logs, metrics and traces to GCP.